### PR TITLE
Colorize last column

### DIFF
--- a/rainbow-csv.el
+++ b/rainbow-csv.el
@@ -109,7 +109,7 @@
                              (line-beginning-position) (line-end-position))))
          (n (1+ n)))
     (dotimes (i n)
-      (let* ((r (format "^\\([^%c\n]+%c\\)\\{%d\\}"
+      (let* ((r (format "^\\([^%c\n]+[%c\n]\\)\\{%d\\}"
                         separator separator (1+ i)))
              (len (length rainbow-csv-colors))
              (color (nth (% i len) rainbow-csv-colors)))


### PR DESCRIPTION
The last column is never colorized without the patch proposed in this commit. In the [demo image](https://github.com/emacs-vs/rainbow-csv/blob/master/etc/demo.png) shown in the [README.md](https://github.com/emacs-vs/rainbow-csv/blob/master/README.md) file, the last column is shown colorized, but this is done by csv-mode (**not** by rainbow-csv-mode), which colorizes all texts between quotes (`"`). If the quotes are removed from the last column, then the text appears in the default color. This can be furthermore attested by the fact that, in the demo image, the color of the last column should be the same as the color in the fifth column, what is not the case.