### PR TITLE
Use darker colors in light theme

### DIFF
--- a/rainbow-csv.el
+++ b/rainbow-csv.el
@@ -40,16 +40,29 @@
   :link '(url-link :tag "Repository" "https://github.com/emacs-vs/rainbow-csv"))
 
 (defcustom rainbow-csv-colors
-  '("#CCCCCC"
-    "#569CD6"
-    "#DCCD79"
-    "#529955"
-    "#CE834A"
-    "#8CDCFE"
-    "#B5C078"
-    "#4EC9B0"
-    "#569CD6"
-    "#F44747")
+  (cond
+   ((eq 'light (frame-parameter nil 'background-mode))
+    '("#333333"
+      "#A96329"
+      "#233286"
+      "#AD66AA"
+      "#317CB5"
+      "#732301"
+      "#4A3F87"
+      "#B1364F"
+      "#A96329"
+      "#0BB8B8"))
+    (t
+     '("#CCCCCC"
+       "#569CD6"
+       "#DCCD79"
+       "#529955"
+       "#CE834A"
+       "#8CDCFE"
+       "#B5C078"
+       "#4EC9B0"
+       "#569CD6"
+       "#F44747")))
   "List of colors to use."
   :type 'list
   :group 'rainbow-csv)


### PR DESCRIPTION
In the `defcustom` statement, the value of the variable `rainbow-csv-colors` is chosen according to the user's theme. This change should work for any version of Emacs >= 22.2. However, it has not been extensively tested, since I use only a light theme. Also, it will not work when themes are changed from dark to light during an editing session, since the `defcustom` call is done at Emacs' startup.  